### PR TITLE
The Illidari Council - fixes

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1518285097709086000.sql
+++ b/data/sql/updates/pending_db_world/rev_1518285097709086000.sql
@@ -3,5 +3,5 @@ INSERT INTO version_db_world (`sql_rev`) VALUES ('1518285097709086000');
 -- Evilpriest #0001
 -- Removed MECHANIC_INTERRUPT flag from Lady Malande/High Nethermancer Zerevor (Black Temple) 
 
-UPDATE `creature_template` SET `mechanic_immune_mask` = '617299839' WHERE (`entry`='22951')
+UPDATE `creature_template` SET `mechanic_immune_mask` = '617299839' WHERE (`entry`='22951');
 UPDATE `creature_template` SET `mechanic_immune_mask` = '617299839' WHERE (`entry`='22950')

--- a/data/sql/updates/pending_db_world/rev_1518285097709086000.sql
+++ b/data/sql/updates/pending_db_world/rev_1518285097709086000.sql
@@ -1,0 +1,7 @@
+INSERT INTO version_db_world (`sql_rev`) VALUES ('1518285097709086000');
+
+-- Evilpriest #0001
+-- Removed MECHANIC_INTERRUPT flag from Lady Malande/High Nethermancer Zerevor (Black Temple) 
+
+UPDATE `creature_template` SET `mechanic_immune_mask` = '617299839' WHERE (`entry`='22951')
+UPDATE `creature_template` SET `mechanic_immune_mask` = '617299839' WHERE (`entry`='22950')


### PR DESCRIPTION
As stated in wowwiki and in retail videos, in Black Temple's Council the mage and the priest have spells that should be interruptible. They indeed are but the NPCs aren't currently interruptible.

**Changes proposed:**
-  Modified the mechanic_immune_mask of Lady Malande (id 22951) and High Nethermancer Zerevor (id 22950) in order to make them interruptible.

**Target branch(es):** master

**Tests performed:**
Tested in game.